### PR TITLE
Added short descriptions for meeting minutes.

### DIFF
--- a/001.md
+++ b/001.md
@@ -1,3 +1,10 @@
+<!--
+Title:           Content Security Policy & Proxy External Requests
+Description:     Introduction to Content Security Policy (CSP); the practical benefits, challenges, and limitations of CSP to guard against cross-site scripting attacks (XSS). And: How to proxy requests to external sources through your web server.
+Date:            2018-05-08T19:00
+Location:        Mozilla Berlin
+Location-Search: https://www.openstreetmap.org/node/4996803917
+-->
 # Meetup 001 &ndash; 08.05.2018
 
 Hosted by: moz://a Community Space Berlin

--- a/002.md
+++ b/002.md
@@ -1,3 +1,10 @@
+<!--
+Title:           Git & GitHub Workshop
+Description:     Getting started with Git and GitHub; fork, clone, fetch remotes and create pull requests to make use of the GitHub workflow.
+Date:            2018-05-22T19:00
+Location:        Mozilla Berlin
+Location-Search: https://www.openstreetmap.org/node/4996803917
+-->
 # Meetup 002 &ndash; 23.05.2018
 
 Hosted by: moz://a Community Space Berlin

--- a/meta-001.md
+++ b/meta-001.md
@@ -1,3 +1,10 @@
+<!--
+Title:           Meta: Getting started
+Description:     Outlining the basics to get the meetup started; discussion on communication, topics, locations, hosting and other requirements.
+Date:            2018-04-10T19:00
+Location:        Mozilla Berlin
+Location-Search: https://www.openstreetmap.org/node/4996803917
+-->
 # Meta Meetup 001 - 10.04.18
 
 Hosted by: moz://a Community Space Berlin
@@ -82,12 +89,6 @@ Hello, and welcome to our very first meta meetup. We are about to start a topic-
 * Attract more WordPress developers
 * Find new locations
 * Gather interesting topics to talk about
-
-### Open tasks
-
-* Setup Slack channel: [@alpipego](https://github.com/alpipego)
-* Collect email addresses: [@berlindave](https://github.com/berlindave)
-* Publish meetup notes: [@hofmannsven](https://github.com/hofmannsven)
 
 ### Next meetup: Monday 16th of April 2018
 > moz://a Community Space Berlin, 

--- a/meta-002.md
+++ b/meta-002.md
@@ -1,3 +1,10 @@
+<!--
+Title:           Meta: Git & GitHub Workflow
+Description:     Mastering our Git and GitHub workflow; working with our repositories, handling issues and how to make use of GitHub features.
+Date:            2018-04-16T19:00
+Location:        Mozilla Berlin
+Location-Search: https://www.openstreetmap.org/node/4996803917
+-->
 # Meta Meetup 002 - 16.04.18
 
 Hosted by: moz://a Community Space Berlin
@@ -77,7 +84,7 @@ On the second meta meetup, we introduced Git and GitHub to the meta team and sch
 
 ### Further reading
 
-* _All things WordPress_ episode on [PHP Roundtable Podcast](https://www.phproundtable.com/) with [Ryan Welcher](https://twitter.com/ryanwelcher) and [David Hayes](https://twitter.com/davidbhayes)
+* _All things WordPress_ episode on [PHP Roundtable Podcast](https://www.phproundtable.com/episode/all-things-wordpress) with [Ryan Welcher](https://twitter.com/ryanwelcher) and [David Hayes](https://twitter.com/davidbhayes)
 
 ### First public meetup: Tuesday, May 8th 2018
 > moz://a Community Space Berlin, 


### PR DESCRIPTION
Added short descriptions for all previous meeting minutes. (Cross-repository reference: wp-berlin/tech-website#21)

This pull request also adds the permalink to the PHP Roundtable Podcast episode and cleans up the open tasks from the first meta minutes.