### PR TITLE
004 whitespace and emoji fixes (last one, promised)

### DIFF
--- a/004.md
+++ b/004.md
@@ -158,7 +158,7 @@ Copyright 2015, Google Inc.
 > —[Alberto Medina](https://medinathoughts.com/2018/05/17/progressive-wordpress/)
 
 
-> “How much should [people] need to know about how the web works in order to be able to publish some content?”
+> “How much should [people] need to know about how the web works in order to be able to publish some content?”
 > —[Morten Rand-Hendriksen](https://youtu.be/UQlRiyOvmns?t=4m35s)
 
 
@@ -222,5 +222,5 @@ WordPress and AMP—concerns:
 #### Articles
 
 - [Progressive WordPress](https://medinathoughts.com/2018/05/17/progressive-wordpress)
-- [Standardizing lessons learned from AMP ](https://amphtml.wordpress.com/2018/03/08/standardizing-lessons-learned-from-amp/)
-- [Contributing to the AMP Project ](https://amphtml.wordpress.com/2018/06/21/contributing-to-the-amp-project/)
+- [Standardizing lessons learned from AMP ](https://amphtml.wordpress.com/2018/03/08/standardizing-lessons-learned-from-amp/)
+- [Contributing to the AMP Projectt](https://amphtml.wordpress.com/2018/06/21/contributing-to-the-amp-project/)

--- a/004.md
+++ b/004.md
@@ -222,5 +222,5 @@ WordPress and AMP—concerns:
 #### Articles
 
 - [Progressive WordPress](https://medinathoughts.com/2018/05/17/progressive-wordpress)
-- [Standardizing lessons learned from AMP ](https://amphtml.wordpress.com/2018/03/08/standardizing-lessons-learned-from-amp/)
+- [Standardizing lessons learned from AMP](https://amphtml.wordpress.com/2018/03/08/standardizing-lessons-learned-from-amp/)
 - [Contributing to the AMP Projectt](https://amphtml.wordpress.com/2018/06/21/contributing-to-the-amp-project/)

--- a/004.md
+++ b/004.md
@@ -102,7 +102,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write HTML                           | 🥪                                    |
+| Write HTML                           | 🥐                                   |
 | Write JavaScript                     | ☕️                                    |
 | Write CSS                            | Import component                     |
 | Customise design                     | Customise design                     |
@@ -119,7 +119,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write semantic HTML                  | 🥪                                    |
+| Write semantic HTML                  | 🥐                                   |
 | Write performant JavaScript          | ☕️                                    |
 | Write x-browser CSS                  | Import component                     |
 | Customise design                     | Customise design                     |

--- a/004.md
+++ b/004.md
@@ -154,11 +154,11 @@ Copyright 2015, Google Inc.
 - Enable progressive web applications (PWA)
 - Create user-first experiences
 
-> “We must strive to close  the Capability/Usage gap … to democratise the building of delightful user experiences on the web.”
+> “We must strive to close the Capability/Usage gap … to democratise the building of delightful user experiences on the web.”
 > —[Alberto Medina](https://medinathoughts.com/2018/05/17/progressive-wordpress/)
 
 
-> “How much should [people] need to know about how the web works in order to be able to publish some content?”
+> “How much should [people] need to know about how the web works in order to be able to publish some content?”
 > —[Morten Rand-Hendriksen](https://youtu.be/UQlRiyOvmns?t=4m35s)
 
 

--- a/004.md
+++ b/004.md
@@ -102,7 +102,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write HTML                           | 🥪🥪                                  |
+| Write HTML                           | 🥪                                    |
 | Write JavaScript                     | ☕️                                    |
 | Write CSS                            | Import component                     |
 | Customise design                     | Customise design                     |
@@ -119,7 +119,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write semantic HTML                  | 🥪🥪                                  |
+| Write semantic HTML                  | 🥪                                    |
 | Write performant JavaScript          | ☕️                                    |
 | Write x-browser CSS                  | Import component                     |
 | Customise design                     | Customise design                     |

--- a/004.md
+++ b/004.md
@@ -102,7 +102,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write HTML                           | 🥪 🥪                                 |
+| Write HTML                           | 🥪🥪                                  |
 | Write JavaScript                     | ☕️                                    |
 | Write CSS                            | Import component                     |
 | Customise design                     | Customise design                     |
@@ -119,7 +119,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write semantic HTML                  | 🥪 🥪                                 |
+| Write semantic HTML                  | 🥪🥪                                  |
 | Write performant JavaScript          | ☕️                                    |
 | Write x-browser CSS                  | Import component                     |
 | Customise design                     | Customise design                     |

--- a/004.md
+++ b/004.md
@@ -102,7 +102,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write HTML                           | 🥪🥪                                  |
+| Write HTML                           | 🥪 🥪                                 |
 | Write JavaScript                     | ☕️                                    |
 | Write CSS                            | Import component                     |
 | Customise design                     | Customise design                     |
@@ -119,7 +119,7 @@ Copyright 2015, Google Inc.
 
 | Code from scratch                    | Use framework                        |
 |--------------------------------------|--------------------------------------|
-| Write semantic HTML                  | 🥪🥪                                  |
+| Write semantic HTML                  | 🥪 🥪                                 |
 | Write performant JavaScript          | ☕️                                    |
 | Write x-browser CSS                  | Import component                     |
 | Customise design                     | Customise design                     |


### PR DESCRIPTION
I had noticed a couple of whitespace glitches (copypasta gone wrong from Keynote), and the sandwich emoji apparently isn’t supported on recent Android/Samsung, although it [should be](https://unicode.org/emoji/charts/full-emoji-list.html#1f96a).

Anyways, this PR fixes all of the above. Thanks!

---

_Screenshots: whitespace glitches_

![2018-07-05 13 43 29](https://user-images.githubusercontent.com/308422/42368465-62f053e6-8107-11e8-8f44-c5271d486388.png)
![2018-07-05 13 45 14](https://user-images.githubusercontent.com/308422/42368467-630b3bf2-8107-11e8-9987-0e74dc526ead.png)